### PR TITLE
Fix THREE undefined error by importing three.js module

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,6 @@
         </div>
     </div>
 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r152/three.min.js"></script>
-    <script src="script.js"></script>
+    <script type="module" src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,3 +1,5 @@
+import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.152.0/build/three.module.js';
+
 document.addEventListener('DOMContentLoaded', () => {
     // --- DOM Elements ---
     const playerHandElement = document.getElementById('player-hand');


### PR DESCRIPTION
## Summary
- load script.js as module and import three.js to ensure THREE is defined

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b327bc59b08325bfdacbbeef1a56e4